### PR TITLE
fix: 公開サイト (docs / LP / llms.txt / privacy) を新 API・MCP 仕様に追従

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -48,10 +48,8 @@
         <div class="text-xs uppercase tracking-wider text-gray-500 mb-2 mt-4">REST API</div>
         <a href="#overview" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">Overview</a>
         <a href="#check-domain" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">check-domain</a>
-        <a href="#check-url" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">check-url</a>
         <a href="#list-threats" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">list-threats</a>
         <a href="#stats" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">stats</a>
-        <a href="#report-threat-api" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">report-threat</a>
         <div class="text-xs uppercase tracking-wider text-gray-500 mb-2 mt-6">MCP Server</div>
         <a href="#mcp" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">Connection Guide</a>
         <a href="#mcp-tools" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">Available Tools</a>
@@ -127,24 +125,6 @@
         </div>
       </section>
 
-      <!-- check-url -->
-      <section id="check-url">
-        <h2 class="text-2xl font-bold mb-4">check-url</h2>
-        <div class="flex items-center gap-2 mb-4">
-          <span class="px-2 py-0.5 rounded text-xs font-bold bg-green-500/20 text-green-400">GET</span>
-          <code class="text-sm text-gray-300">/api/check-url?url={url}</code>
-        </div>
-        <p class="text-gray-400 text-sm mb-4">Check a specific URL. Extracts the domain and checks for threats, also matching URL-specific entries.</p>
-        <table class="w-full text-sm mb-4">
-          <thead><tr class="text-left text-gray-500 border-b border-gray-800"><th class="pb-2 pr-4">Name</th><th class="pb-2 pr-4">Type</th><th class="pb-2 pr-4">Required</th><th class="pb-2">Description</th></tr></thead>
-          <tbody><tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">url</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">Yes</td><td class="py-2 text-gray-400">Full URL to check</td></tr></tbody>
-        </table>
-        <div class="relative">
-          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
-          <pre><code class="language-bash">curl -s "https://hasthissitebeenpoisoned.ai/api/check-url?url=https://cblanke2.pages.dev/" | jq .</code></pre>
-        </div>
-      </section>
-
       <!-- list-threats -->
       <section id="list-threats">
         <h2 class="text-2xl font-bold mb-4">list-threats</h2>
@@ -182,41 +162,6 @@
         </div>
       </section>
 
-      <!-- report-threat -->
-      <section id="report-threat-api">
-        <h2 class="text-2xl font-bold mb-4">report-threat</h2>
-        <div class="flex items-center gap-2 mb-4">
-          <span class="px-2 py-0.5 rounded text-xs font-bold bg-amber-500/20 text-amber-400">POST</span>
-          <code class="text-sm text-gray-300">/api/report-threat</code>
-        </div>
-        <p class="text-gray-400 text-sm mb-4">Report a suspected IDPI threat URL. Creates a GitHub Issue for tracking. The report will be automatically verified and registered if confirmed during the next daily collection run.</p>
-        <h3 class="text-sm font-semibold text-gray-300 mb-2">Request Body (JSON)</h3>
-        <table class="w-full text-sm mb-4">
-          <thead><tr class="text-left text-gray-500 border-b border-gray-800"><th class="pb-2 pr-4">Name</th><th class="pb-2 pr-4">Type</th><th class="pb-2 pr-4">Required</th><th class="pb-2">Description</th></tr></thead>
-          <tbody>
-            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">url</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">Yes</td><td class="py-2 text-gray-400">Full URL suspected of containing IDPI payloads</td></tr>
-            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">severity</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">No</td><td class="py-2 text-gray-400">Estimated severity: critical, high, medium, low</td></tr>
-            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">description</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">No</td><td class="py-2 text-gray-400">Description of the suspected threat</td></tr>
-          </tbody>
-        </table>
-        <div class="relative">
-          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
-          <pre><code class="language-bash">curl -X POST "https://hasthissitebeenpoisoned.ai/api/report-threat" \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://example.com/suspicious","severity":"high","description":"Hidden instructions found"}'</code></pre>
-        </div>
-        <h3 class="text-sm font-semibold text-gray-300 mt-4 mb-2">Response (201 Created)</h3>
-        <div class="relative">
-          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
-          <pre><code class="language-json">{
-  "success": true,
-  "message": "Threat report created. It will be automatically verified during the next daily collection.",
-  "issue_url": "https://github.com/tanbablack/htsbp/issues/42",
-  "issue_number": 42
-}</code></pre>
-        </div>
-      </section>
-
       <!-- MCP -->
       <section id="mcp">
         <h2 class="text-2xl font-bold mb-4">MCP Server</h2>
@@ -246,19 +191,9 @@
             <p class="text-gray-500 text-xs mt-1">Input: <code>{ domain: string }</code></p>
           </div>
           <div class="bg-gray-900 rounded-xl p-4 border border-gray-800">
-            <code class="text-accent font-semibold">check_url</code>
-            <p class="text-gray-400 text-sm mt-1">Check if a specific URL contains known IDPI payloads.</p>
-            <p class="text-gray-500 text-xs mt-1">Input: <code>{ url: string }</code></p>
-          </div>
-          <div class="bg-gray-900 rounded-xl p-4 border border-gray-800">
             <code class="text-accent font-semibold">list_threats</code>
             <p class="text-gray-400 text-sm mt-1">List known IDPI threats with optional filters.</p>
             <p class="text-gray-500 text-xs mt-1">Input: <code>{ severity?: string, intent?: string, limit?: number }</code></p>
-          </div>
-          <div class="bg-gray-900 rounded-xl p-4 border border-gray-800">
-            <code class="text-accent font-semibold">report_threat</code>
-            <p class="text-gray-400 text-sm mt-1">Report a suspected IDPI threat URL for investigation. Creates a tracked report that will be automatically verified.</p>
-            <p class="text-gray-500 text-xs mt-1">Input: <code>{ url: string, severity?: string, description?: string }</code></p>
           </div>
         </div>
       </section>
@@ -338,9 +273,9 @@ curl -s "https://hasthissitebeenpoisoned.ai/api/stats" | jq .</code></pre>
         <div class="relative">
           <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
           <pre><code class="language-typescript">import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-const transport = new SSEClientTransport(
+const transport = new StreamableHTTPClientTransport(
   new URL("https://hasthissitebeenpoisoned.ai/api/mcp")
 );
 const client = new Client({ name: "my-app", version: "1.0.0" });
@@ -351,27 +286,25 @@ console.log(result);</code></pre>
         </div>
       </section>
 
-      <!-- Report -->
+      <!-- Contribute -->
       <section id="report">
-        <h2 class="text-2xl font-bold mb-4">Report a Threat</h2>
-        <p class="text-gray-400 mb-4">Found a website with hidden prompt injection targeting AI agents? Report it. All reports are automatically verified and registered if confirmed.</p>
+        <h2 class="text-2xl font-bold mb-4">Contribute a Threat</h2>
+        <p class="text-gray-400 mb-4">Found a website with hidden prompt injection targeting AI agents? Open a Pull Request. The CI workflow auto-runs reachability + AI-malice scan and source-credibility research, posts the verdict as a PR comment, and blocks merge if the entry is not verifiable.</p>
 
-        <h3 class="text-sm font-semibold text-gray-300 mb-3">For AI Agents</h3>
-        <p class="text-gray-400 text-sm mb-3">Use the MCP <code class="text-accent">report_threat</code> tool or <code class="text-accent">POST /api/report-threat</code> endpoint to report threats programmatically. Reports are automatically verified during the next daily collection run.</p>
-
-        <h3 class="text-sm font-semibold text-gray-300 mb-3 mt-6">For Humans</h3>
-        <a href="https://github.com/tanbablack/htsbp/issues/new?template=new-threat.yml" target="_blank" rel="noopener"
+        <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener"
            class="inline-block px-6 py-3 rounded-lg bg-accent text-bg font-semibold hover:bg-cyan-400 transition">
-          Report a Suspected IDPI Site
+          Open a Pull Request on GitHub
         </a>
+
         <div class="mt-6 bg-gray-900 rounded-xl p-4 border border-gray-800 text-sm text-gray-400">
-          <p class="mb-2">When reporting, please include:</p>
+          <p class="mb-2">Add <code class="text-accent">data/threats/domains/&lt;host&gt;.json</code> with at minimum:</p>
           <ul class="list-disc list-inside space-y-1">
-            <li>The full URL of the suspected page</li>
-            <li>Your estimated severity (critical / high / medium / low)</li>
-            <li>A description of what hidden instructions or suspicious behavior you observed</li>
+            <li>The full URL where the IDPI payload was observed</li>
+            <li>Your estimated <code class="text-accent">severity</code> (critical / high / medium / low)</li>
+            <li>A description of the hidden instructions or behavior</li>
+            <li><code class="text-accent">source_url</code> — a citation to the original report or evidence (required)</li>
           </ul>
-          <p class="mt-3 text-gray-500">Reports are automatically verified by our scanner. If IDPI patterns are detected, the threat is registered into our database without manual approval.</p>
+          <p class="mt-3 text-gray-500">The PR validation workflow scans the entry with our shared <code class="text-accent">scan</code> + <code class="text-accent">research</code> libraries. Entries without a credible <code class="text-accent">source_url</code> or that are unreachable + unverifiable will fail CI and cannot be merged.</p>
         </div>
       </section>
 

--- a/public/index.html
+++ b/public/index.html
@@ -142,7 +142,7 @@
         <p class="text-gray-400 mb-8">Integrate HTSBP into your workflow via REST API or MCP server.</p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
           <a href="/docs.html" class="px-6 py-3 rounded-lg bg-accent text-bg font-semibold hover:bg-cyan-400 transition">Read the Docs</a>
-          <a href="https://github.com/tanbablack/htsbp/issues/new?template=new-threat.yml" target="_blank" rel="noopener" class="px-6 py-3 rounded-lg border border-gray-600 text-gray-300 font-semibold hover:border-gray-400 hover:text-gray-100 transition">Report a Threat</a>
+          <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener" class="px-6 py-3 rounded-lg border border-gray-600 text-gray-300 font-semibold hover:border-gray-400 hover:text-gray-100 transition">Contribute a Threat (PR)</a>
         </div>
       </div>
     </section>
@@ -261,8 +261,8 @@
         resultsDiv.innerHTML = `
           <div class="animate-fade-in rounded-xl border border-green-500/50 bg-green-950/30 p-6 glow-safe">
             <div class="text-xl font-bold text-green-400 mb-2">Good news — no threats found!</div>
-            <p class="text-gray-400 text-sm mb-3">This domain is not in our threat database. If you believe it should be, please report it.</p>
-            <a href="https://github.com/tanbablack/htsbp/issues/new?template=new-threat.yml" target="_blank" rel="noopener" class="text-accent text-sm hover:underline">Report this domain &rarr;</a>
+            <p class="text-gray-400 text-sm mb-3">This domain is not in our threat database. If you believe it should be, please contribute it via Pull Request.</p>
+            <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener" class="text-accent text-sm hover:underline">Contribute via PR &rarr;</a>
           </div>`;
       }
     }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,10 +17,8 @@ Base URL: `https://hasthissitebeenpoisoned.ai/api`
 ### Endpoints
 
 - `GET /api/check-domain?domain={domain}` — Check if a domain hosts known IDPI threats
-- `GET /api/check-url?url={url}` — Check a specific URL for IDPI payloads
 - `GET /api/list-threats?severity={severity}&intent={intent}&limit={limit}` — List known threats with filters
 - `GET /api/stats` — Aggregate statistics about the threat database
-- `POST /api/report-threat` — Report a suspected IDPI threat (body: `{ url, severity?, description? }`)
 
 ## MCP Server
 
@@ -42,17 +40,18 @@ Protocol: Streamable HTTP (JSON-RPC 2.0)
 ### Tools
 
 - `check_domain` — Check if a domain hosts known IDPI attacks. Input: `{ domain: string }`
-- `check_url` — Check if a URL contains known IDPI payloads. Input: `{ url: string }`
 - `list_threats` — List known threats with optional filters. Input: `{ severity?: string, intent?: string, limit?: number }`
-- `report_threat` — Report a suspected IDPI threat. Input: `{ url: string, severity?: string, description?: string }`
 
 ## Data Sources
 
-- Unit 42 (Palo Alto Networks) — Daily IoC feeds
-- AlienVault OTX — Discovery & verification
-- tldrsec/prompt-injection-defenses — Curated list (weekly)
-- AI Web Crawler (OpenClaw) — Active analysis (daily)
-- Community Reports — GitHub Issues & MCP/API (continuous)
+- Unit 42 (Palo Alto Networks) — Discovered via Claude web search
+- AlienVault OTX — IoC API (pulses tagged "prompt injection" / "IDPI")
+
+All threat records cite an explicit `source_url` (mandatory schema field). Daily collection re-verifies reachability and AI-malice signals; changes are submitted as pull requests for human review.
+
+## Contributing
+
+Add `data/threats/domains/<host>.json` via Pull Request on GitHub. The CI workflow runs reachability + AI-malice scan and source-credibility research, posts the verdict as a PR comment, and blocks merge if the entry is not verifiable. `source_url` is required.
 
 ## Documentation
 

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -51,14 +51,8 @@
         </ul>
         <p class="mt-3">We do <strong class="text-white">not</strong> collect IP addresses, user identifiers, or personal information from API requests. Analytics are server-side via Netlify Analytics and contain no personally identifiable information.</p>
 
-        <h3 class="text-base font-medium text-gray-200 mt-5 mb-2">2b. Threat Reports</h3>
-        <p>When you submit a threat report (via MCP <code class="text-cyan-400">report_threat</code>, POST API, or GitHub Issues), we collect:</p>
-        <ul class="list-disc ml-6 mt-2 space-y-1">
-          <li>The reported URL</li>
-          <li>Optional description you provide</li>
-          <li>Submission timestamp</li>
-        </ul>
-        <p class="mt-3">Reports submitted via GitHub Issues are governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener" class="text-cyan-400 hover:underline">GitHub's Privacy Policy</a>.</p>
+        <h3 class="text-base font-medium text-gray-200 mt-5 mb-2">2b. Threat Contributions (Pull Requests)</h3>
+        <p>When you contribute a threat entry via Pull Request on GitHub, the submission is governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener" class="text-cyan-400 hover:underline">GitHub's Privacy Policy</a>. The PR validation workflow fetches the contributed URL once to verify reachability and presence of IDPI payloads; no information about the contributor is collected by HTSBP beyond what GitHub already exposes via the PR.</p>
       </section>
 
       <section>


### PR DESCRIPTION
廃止した API エンドポイント (`check-url` / `report-threat`) と MCP ツール (`check_url` / `report_threat`)、削除済みの Issue テンプレ (`new-threat.yml`) への参照を、公開静的サイトから除去。

## 修正内容

- `public/docs.html` — サイドバー / API セクション / MCP Tools / Sample (MCP Client) / Report a Threat セクションを刷新。MCP Client サンプルは Streamable HTTP transport に差し替え。「Report a Threat」を「Contribute a Threat (PR)」に置き換え
- `public/index.html` — ヒーロー下「Report a Threat」ボタンと「Good news」ブロックの Issue リンクを PR ベース貢献導線に変更
- `public/llms.txt` — エンドポイント一覧と MCP ツール一覧を新仕様に合わせる。Data Sources を Unit42 + OTX-API に整理。Contributing 章を追加
- `public/privacy.html` — 「Threat Reports」セクションを「Threat Contributions (Pull Requests)」に書き換え

## 検証

```bash
grep -nE "check-url|report-threat|check_url|report_threat|new-threat\\.yml" public/*.{html,txt}
# (no matches)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5fjck3UHJqNYB6m1pAdBu)_