### PR TITLE
feat: report-threat API/MCP を復活 (PR 事前検証と同じ pipeline を共有)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ AI エージェントを標的に間接プロンプトインジェクション (
 
 | 経路 | 内容 |
 |---|---|
-| REST API | `/api/check-domain` `/api/list-threats` `/api/stats` `/api/mcp` |
-| MCP | ツール `check_domain` / `list_threats` |
+| REST API | `/api/check-domain` `/api/list-threats` `/api/stats` `/api/report-threat` `/api/mcp` |
+| MCP | ツール `check_domain` / `list_threats` / `report_threat` |
 | 静的 DL | `data/` 配下を Netlify 静的配信 + GitHub raw URL |
 
 ### REST API
@@ -201,11 +201,19 @@ npm install
 npm run dev
 ```
 
-## Contributing
+## Threat 通報経路
 
-新規 IDPI サイトの貢献は **PR 経由** で受け付ける。`data/threats/domains/<host>.json` を作成して PR を起票すれば `pr-validate.yml` が自動で観点 1+2 を実行し、結果をコメントする。`source_url` (出典) は必須。
+新規 IDPI サイトの通報は 3 経路すべてが **同じ検証パイプライン** (`pr-validate.yml` の scan + research) を通り、最終的にレビュアーが PR を merge することで初めて公開フィードに反映される。
 
-PR を merge できるのはレビュアーのみ。完全自動 merge は許可しない。
+| 経路 | 入口 | 動作 |
+|---|---|---|
+| **REST API** | `POST /api/report-threat` | URL + `source_url` + `description` を JSON で受け、`src/lib/report.ts` が GitHub REST API でブランチ (`report/<host>-<ts>`) と PR を起票。レスポンスに PR URL を返す |
+| **MCP** | ツール `report_threat` | 同入力。AI エージェントから直接呼べる。同じ `submitThreatReport()` を共有 |
+| **PR 直接** | GitHub 上で `data/threats/domains/<host>.json` を編集する PR | 自分でファイルを書いて PR を起票 |
+
+3 経路いずれの PR も `pr-validate.yml` (auto/* 以外で発火) が観点 1+2 を実行し、結果を PR コメントに投稿。`source_url` 欠落・到達不能 + 出典裏付けなしは CI 失敗で merge ブロック。
+
+`source_url` (出典) は必須。完全自動 merge は許可しない。
 
 ## License
 

--- a/public/docs.html
+++ b/public/docs.html
@@ -50,6 +50,7 @@
         <a href="#check-domain" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">check-domain</a>
         <a href="#list-threats" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">list-threats</a>
         <a href="#stats" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">stats</a>
+        <a href="#report-threat-api" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">report-threat</a>
         <div class="text-xs uppercase tracking-wider text-gray-500 mb-2 mt-6">MCP Server</div>
         <a href="#mcp" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">Connection Guide</a>
         <a href="#mcp-tools" class="sidebar-link block pl-3 py-1.5 border-l-2 border-transparent text-gray-400 hover:text-gray-200 transition">Available Tools</a>
@@ -162,6 +163,55 @@
         </div>
       </section>
 
+      <!-- report-threat -->
+      <section id="report-threat-api">
+        <h2 class="text-2xl font-bold mb-4">report-threat</h2>
+        <div class="flex items-center gap-2 mb-4">
+          <span class="px-2 py-0.5 rounded text-xs font-bold bg-amber-500/20 text-amber-400">POST</span>
+          <code class="text-sm text-gray-300">/api/report-threat</code>
+        </div>
+        <p class="text-gray-400 text-sm mb-4">Submit a suspected IDPI threat. Opens a Pull Request which is automatically validated by the same scan + research pipeline used for human PRs (observation 1: reachability + AI malicious code analysis; observation 2: source_url credibility + domain reputation via web search). Returns the PR URL — the threat is registered only after a reviewer merges the PR.</p>
+        <h3 class="text-sm font-semibold text-gray-300 mb-2">Request Body (JSON)</h3>
+        <table class="w-full text-sm mb-4">
+          <thead><tr class="text-left text-gray-500 border-b border-gray-800"><th class="pb-2 pr-4">Name</th><th class="pb-2 pr-4">Type</th><th class="pb-2 pr-4">Required</th><th class="pb-2">Description</th></tr></thead>
+          <tbody>
+            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">url</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">Yes</td><td class="py-2 text-gray-400">URL where the IDPI payload was observed (http/https)</td></tr>
+            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">source_url</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">Yes</td><td class="py-2 text-gray-400">URL of the supporting evidence/citation (article, IoC, blog post)</td></tr>
+            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">description</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">Yes</td><td class="py-2 text-gray-400">What was observed (location of hidden instructions, wording, behavior — min 20 chars)</td></tr>
+            <tr class="border-b border-gray-800/50"><td class="py-2 pr-4 text-accent">severity</td><td class="py-2 pr-4 text-gray-400">string</td><td class="py-2 pr-4 text-gray-400">No</td><td class="py-2 text-gray-400">Submitter's estimate (critical / high / medium / low). Re-derived by scan.</td></tr>
+          </tbody>
+        </table>
+        <div class="relative">
+          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
+          <pre><code class="language-bash">curl -X POST "https://hasthissitebeenpoisoned.ai/api/report-threat" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/suspicious",
+    "source_url": "https://researcher.example.com/2026/idpi-report",
+    "description": "Hidden &lt;div style=font-size:0&gt; in the footer with prompt-injection text targeting AI agents",
+    "severity": "high"
+  }'</code></pre>
+        </div>
+        <h3 class="text-sm font-semibold text-gray-300 mt-4 mb-2">Response (201 Created)</h3>
+        <div class="relative">
+          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
+          <pre><code class="language-json">{
+  "success": true,
+  "message": "PR を起票しました。pr-validate ワークフローが自動検証を実行します。",
+  "pr_url": "https://github.com/tanbablack/htsbp/pull/123",
+  "pr_number": 123,
+  "branch": "report/example.com-1714000000000",
+  "host": "example.com"
+}</code></pre>
+        </div>
+        <h3 class="text-sm font-semibold text-gray-300 mt-4 mb-2">Error responses</h3>
+        <ul class="list-disc list-inside text-gray-400 text-sm space-y-1">
+          <li><code class="text-accent">400</code> — invalid url / source_url / description / severity (returned with <code>{ error: &lt;field&gt;, message }</code>)</li>
+          <li><code class="text-accent">405</code> — wrong HTTP method</li>
+          <li><code class="text-accent">500</code> — GitHub API or internal error</li>
+        </ul>
+      </section>
+
       <!-- MCP -->
       <section id="mcp">
         <h2 class="text-2xl font-bold mb-4">MCP Server</h2>
@@ -194,6 +244,11 @@
             <code class="text-accent font-semibold">list_threats</code>
             <p class="text-gray-400 text-sm mt-1">List known IDPI threats with optional filters.</p>
             <p class="text-gray-500 text-xs mt-1">Input: <code>{ severity?: string, intent?: string, limit?: number }</code></p>
+          </div>
+          <div class="bg-gray-900 rounded-xl p-4 border border-gray-800">
+            <code class="text-accent font-semibold">report_threat</code>
+            <p class="text-gray-400 text-sm mt-1">Submit a suspected IDPI threat. Opens a Pull Request that is automatically validated by the same scan + research pipeline used for human PRs. Returns the PR URL.</p>
+            <p class="text-gray-500 text-xs mt-1">Input: <code>{ url: string, source_url: string, description: string, severity?: string }</code></p>
           </div>
         </div>
       </section>
@@ -289,22 +344,30 @@ console.log(result);</code></pre>
       <!-- Contribute -->
       <section id="report">
         <h2 class="text-2xl font-bold mb-4">Contribute a Threat</h2>
-        <p class="text-gray-400 mb-4">Found a website with hidden prompt injection targeting AI agents? Open a Pull Request. The CI workflow auto-runs reachability + AI-malice scan and source-credibility research, posts the verdict as a PR comment, and blocks merge if the entry is not verifiable.</p>
+        <p class="text-gray-400 mb-4">Found a website with hidden prompt injection targeting AI agents? You have three equivalent paths — all of them go through the same validation pipeline (scan + research) and require a reviewer to merge before the threat is registered.</p>
 
+        <h3 class="text-sm font-semibold text-gray-300 mb-2">Path A: REST API (programmatic)</h3>
+        <p class="text-gray-400 text-sm mb-3">Send <code class="text-accent">POST /api/report-threat</code>. The API opens a PR on your behalf and returns the PR URL. See the <a href="#report-threat-api" class="text-accent hover:underline">report-threat</a> endpoint docs above.</p>
+
+        <h3 class="text-sm font-semibold text-gray-300 mt-5 mb-2">Path B: MCP (AI agents)</h3>
+        <p class="text-gray-400 text-sm mb-3">Call the <code class="text-accent">report_threat</code> MCP tool. Same underlying flow as the REST API — a PR is opened and the URL returned.</p>
+
+        <h3 class="text-sm font-semibold text-gray-300 mt-5 mb-2">Path C: Pull Request (manual)</h3>
+        <p class="text-gray-400 text-sm mb-3">Add <code class="text-accent">data/threats/domains/&lt;host&gt;.json</code> directly via a PR on GitHub.</p>
         <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener"
            class="inline-block px-6 py-3 rounded-lg bg-accent text-bg font-semibold hover:bg-cyan-400 transition">
           Open a Pull Request on GitHub
         </a>
 
         <div class="mt-6 bg-gray-900 rounded-xl p-4 border border-gray-800 text-sm text-gray-400">
-          <p class="mb-2">Add <code class="text-accent">data/threats/domains/&lt;host&gt;.json</code> with at minimum:</p>
+          <p class="mb-2">All paths require:</p>
           <ul class="list-disc list-inside space-y-1">
             <li>The full URL where the IDPI payload was observed</li>
-            <li>Your estimated <code class="text-accent">severity</code> (critical / high / medium / low)</li>
+            <li><code class="text-accent">source_url</code> — citation to the original report or evidence (required)</li>
             <li>A description of the hidden instructions or behavior</li>
-            <li><code class="text-accent">source_url</code> — a citation to the original report or evidence (required)</li>
+            <li>(Optional) Your estimated <code class="text-accent">severity</code> (critical / high / medium / low) — the scan pipeline re-derives the final value</li>
           </ul>
-          <p class="mt-3 text-gray-500">The PR validation workflow scans the entry with our shared <code class="text-accent">scan</code> + <code class="text-accent">research</code> libraries. Entries without a credible <code class="text-accent">source_url</code> or that are unreachable + unverifiable will fail CI and cannot be merged.</p>
+          <p class="mt-3 text-gray-500">The PR validation workflow runs our shared <code class="text-accent">scan</code> + <code class="text-accent">research</code> libraries and posts the verdict as a PR comment. Entries without a credible <code class="text-accent">source_url</code> or that are unreachable + unverifiable will fail CI and cannot be merged.</p>
         </div>
       </section>
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,6 +19,7 @@ Base URL: `https://hasthissitebeenpoisoned.ai/api`
 - `GET /api/check-domain?domain={domain}` — Check if a domain hosts known IDPI threats
 - `GET /api/list-threats?severity={severity}&intent={intent}&limit={limit}` — List known threats with filters
 - `GET /api/stats` — Aggregate statistics about the threat database
+- `POST /api/report-threat` — Submit a suspected IDPI threat. Body: `{ url, source_url, description, severity? }`. Opens a PR validated by the same scan + research pipeline used for human PRs; returns the PR URL.
 
 ## MCP Server
 
@@ -41,6 +42,7 @@ Protocol: Streamable HTTP (JSON-RPC 2.0)
 
 - `check_domain` — Check if a domain hosts known IDPI attacks. Input: `{ domain: string }`
 - `list_threats` — List known threats with optional filters. Input: `{ severity?: string, intent?: string, limit?: number }`
+- `report_threat` — Submit a suspected IDPI threat. Input: `{ url: string, source_url: string, description: string, severity?: string }`. Opens a PR; same validation pipeline as human PRs. Returns the PR URL.
 
 ## Data Sources
 
@@ -51,7 +53,13 @@ All threat records cite an explicit `source_url` (mandatory schema field). Daily
 
 ## Contributing
 
-Add `data/threats/domains/<host>.json` via Pull Request on GitHub. The CI workflow runs reachability + AI-malice scan and source-credibility research, posts the verdict as a PR comment, and blocks merge if the entry is not verifiable. `source_url` is required.
+Three equivalent paths — all go through the same validation pipeline and require a reviewer to merge:
+
+1. **REST API** — `POST /api/report-threat` (programmatic; opens a PR for you)
+2. **MCP tool** — `report_threat` (for AI agents; same flow as REST API)
+3. **Direct PR** — Add `data/threats/domains/<host>.json` via Pull Request on GitHub
+
+The CI workflow (`pr-validate.yml`) runs reachability + AI-malice scan and source-credibility research, posts the verdict as a PR comment, and blocks merge if the entry is not verifiable. `source_url` is required for all paths.
 
 ## Documentation
 

--- a/src/api/report-threat.ts
+++ b/src/api/report-threat.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/report-threat
+ *
+ * URL + 出典 + 説明を受け取り、PR を起票する (検証は pr-validate.yml が PR で実行)。
+ *
+ * 入力 JSON:
+ *   {
+ *     url: string,          // 必須
+ *     source_url: string,   // 必須
+ *     description: string,  // 必須 (20文字以上)
+ *     severity?: "critical" | "high" | "medium" | "low"
+ *   }
+ *
+ * レスポンス:
+ *   201 { pr_url, pr_number, branch, host }
+ *   400 { error: <field>, message }
+ *   500 { error: "internal", message }
+ */
+import {
+  handleCors,
+  jsonResponse,
+  errorResponse,
+  type NetlifyEvent,
+  type NetlifyResponse,
+} from "../lib/data-loader.js";
+import {
+  submitThreatReport,
+  ReportValidationError,
+  type SubmitInput,
+} from "../lib/report.js";
+
+export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => {
+  const cors = handleCors(event);
+  if (cors) return cors;
+
+  if (event.httpMethod !== "POST") {
+    return errorResponse("Method not allowed. Use POST.", 405);
+  }
+  if (!event.body) {
+    return errorResponse("Empty request body");
+  }
+
+  let input: SubmitInput;
+  try {
+    input = JSON.parse(event.body) as SubmitInput;
+  } catch {
+    return errorResponse("Invalid JSON body");
+  }
+
+  try {
+    const result = await submitThreatReport(input);
+    return jsonResponse(
+      {
+        success: true,
+        message: "PR を起票しました。pr-validate ワークフローが自動検証を実行します。",
+        ...result,
+      },
+      201,
+    );
+  } catch (err) {
+    if (err instanceof ReportValidationError) {
+      return jsonResponse({ error: err.field, message: err.message }, 400);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResponse({ error: "internal", message }, 500);
+  }
+};

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -1,0 +1,197 @@
+/**
+ * Threat Report 受付ヘルパー
+ *
+ * /api/report-threat と MCP report_threat ツールから共有される実装。
+ * GitHub REST API を使って:
+ *   1. main の HEAD SHA 取得
+ *   2. ブランチ作成 (report/<host>-<unix_ts>)
+ *   3. data/threats/domains/<host>.json をブランチに作成
+ *   4. PR 起票
+ * を行い、PR URL を返す。検証 (scan + research) は pr-validate.yml が
+ * 当該 PR で自動実行する。
+ *
+ * 環境変数:
+ *   GITHUB_TOKEN      ブランチ作成・ファイル作成・PR 起票に使用
+ *   GITHUB_REPOSITORY owner/repo (例: tanbablack/htsbp)
+ */
+import { isValidHttpUrl, type Severity, type Threat, type ThreatFile } from "../types.js";
+
+const GITHUB_API = "https://api.github.com";
+
+export interface SubmitInput {
+  url: string;
+  source_url: string;
+  description: string;
+  severity?: Severity;
+}
+
+export interface SubmitResult {
+  pr_url: string;
+  pr_number: number;
+  branch: string;
+  host: string;
+}
+
+export class ReportValidationError extends Error {
+  constructor(public readonly field: string, message: string) {
+    super(message);
+    this.name = "ReportValidationError";
+  }
+}
+
+/** 入力を検証し、不備があれば ReportValidationError を throw */
+function validateInput(input: SubmitInput): { host: string } {
+  if (!isValidHttpUrl(input.url)) {
+    throw new ReportValidationError("url", "url は http:// または https:// の正規 URL が必須");
+  }
+  if (!isValidHttpUrl(input.source_url)) {
+    throw new ReportValidationError(
+      "source_url",
+      "source_url は http:// または https:// の正規 URL が必須 (出典明示は HTSBP の必須要件)",
+    );
+  }
+  const description = (input.description ?? "").trim();
+  if (description.length < 20) {
+    throw new ReportValidationError(
+      "description",
+      "description は 20 文字以上の説明文が必須 (観測した隠し命令の場所・文言・挙動など)",
+    );
+  }
+  if (input.severity && !["critical", "high", "medium", "low"].includes(input.severity)) {
+    throw new ReportValidationError(
+      "severity",
+      "severity は critical / high / medium / low のいずれかのみ",
+    );
+  }
+  let host: string;
+  try {
+    host = new URL(input.url).hostname.toLowerCase();
+  } catch {
+    throw new ReportValidationError("url", "url からホスト名を抽出できない");
+  }
+  if (host.length < 4 || !host.includes(".")) {
+    throw new ReportValidationError("url", `url のホスト名 "${host}" が不正`);
+  }
+  return { host };
+}
+
+interface GhContext {
+  token: string;
+  owner: string;
+  repo: string;
+}
+
+function getContext(): GhContext {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!token) throw new Error("GITHUB_TOKEN が未設定");
+  if (!repo || !repo.includes("/")) throw new Error("GITHUB_REPOSITORY (owner/repo) が未設定");
+  const [owner, name] = repo.split("/");
+  return { token, owner, repo: name };
+}
+
+async function ghFetch(
+  ctx: GhContext,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const res = await fetch(`${GITHUB_API}/repos/${ctx.owner}/${ctx.repo}${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${ctx.token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub API ${method} ${path}: ${res.status} ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+function buildThreatFile(host: string, input: SubmitInput): ThreatFile {
+  const now = new Date().toISOString();
+  const threat: Threat = {
+    url: input.url,
+    severity: input.severity ?? "medium",
+    intent: "other",
+    techniques: [],
+    description: input.description.trim(),
+    source: "report-threat",
+    source_url: input.source_url,
+    first_seen: now,
+    last_seen: now,
+    is_active: true,
+  };
+  return { domain: host, threats: [threat], updated_at: now };
+}
+
+function buildPrBody(host: string, input: SubmitInput): string {
+  return [
+    `本 PR は \`/api/report-threat\` または MCP \`report_threat\` ツール経由で送信された脅威レポートを起票したものです。`,
+    "",
+    `## 送信内容`,
+    `- **対象 URL**: ${input.url}`,
+    `- **対象ホスト**: \`${host}\``,
+    `- **出典 (source_url)**: ${input.source_url}`,
+    `- **送信者の severity 見立て**: ${input.severity ?? "(未指定 → medium で初期化)"}`,
+    "",
+    `## 観測内容 (送信者記述)`,
+    "",
+    "> " + input.description.replace(/\n/g, "\n> "),
+    "",
+    `## 検証`,
+    "本 PR は \`pr-validate.yml\` ワークフローによって観点 1 (scan: 到達性 + AI 悪意コード解析 + severity 判定) と観点 2 (research: source_url 妥当性 + ドメイン Web 検索評判) で自動検証され、結果が PR コメントとして投稿されます。検証で問題が検出された場合は CI が失敗し merge ブロックされます。",
+    "",
+    `## レビュアーの判断`,
+    "PR コメントの検証結果を確認し、内容が妥当であれば merge してください。",
+  ].join("\n");
+}
+
+/** メインエントリポイント */
+export async function submitThreatReport(input: SubmitInput): Promise<SubmitResult> {
+  const { host } = validateInput(input);
+  const ctx = getContext();
+
+  // 1. main HEAD SHA
+  const mainRef = (await ghFetch(ctx, "GET", "/git/ref/heads/main")) as {
+    object: { sha: string };
+  };
+  const mainSha = mainRef.object.sha;
+
+  // 2. ブランチ作成
+  const branch = `report/${host}-${Date.now()}`;
+  await ghFetch(ctx, "POST", "/git/refs", {
+    ref: `refs/heads/${branch}`,
+    sha: mainSha,
+  });
+
+  // 3. ファイル作成
+  const filePath = `data/threats/domains/${host}.json`;
+  const content = JSON.stringify(buildThreatFile(host, input), null, 2) + "\n";
+  const contentB64 = Buffer.from(content, "utf-8").toString("base64");
+  await ghFetch(ctx, "PUT", `/contents/${encodeURIComponent(filePath).replace(/%2F/g, "/")}`, {
+    message: `report: ${host} (via API/MCP)`,
+    content: contentB64,
+    branch,
+  });
+
+  // 4. PR 起票
+  const pr = (await ghFetch(ctx, "POST", "/pulls", {
+    title: `report: ${host} (via API/MCP)`,
+    head: branch,
+    base: "main",
+    body: buildPrBody(host, input),
+  })) as { html_url: string; number: number };
+
+  return {
+    pr_url: pr.html_url,
+    pr_number: pr.number,
+    branch,
+    host,
+  };
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,6 +4,11 @@
  * 公開ツール: check_domain / list_threats
  */
 import { loadDomainThreats, loadThreatIndex } from "../lib/data-loader.js";
+import {
+  submitThreatReport,
+  ReportValidationError,
+  type SubmitInput,
+} from "../lib/report.js";
 import type { Threat } from "../types.js";
 
 /* ────────────────────────────────────────────────────────────────────────── */
@@ -61,6 +66,32 @@ const MCP_TOOLS: McpToolDefinition[] = [
       },
     },
     annotations: { readOnlyHint: true, destructiveHint: false },
+  },
+  {
+    name: "report_threat",
+    description:
+      "Report a suspected IDPI threat. Opens a Pull Request which is automatically validated by the same scan + research pipeline used for human PRs (observation 1: reachability + AI malicious code analysis; observation 2: source_url credibility + domain reputation via web search). Returns the PR URL.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "URL where the IDPI payload was observed (required, http/https)" },
+        source_url: {
+          type: "string",
+          description: "URL of the supporting evidence/citation (required, http/https). HTSBP requires every threat record to cite an explicit source.",
+        },
+        description: {
+          type: "string",
+          description: "Description of the observed payload: location, wording, behavior (required, min 20 chars)",
+        },
+        severity: {
+          type: "string",
+          enum: ["critical", "high", "medium", "low"],
+          description: "Submitter's severity estimate (optional; the scan pipeline re-derives the final value)",
+        },
+      },
+      required: ["url", "source_url", "description"],
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   },
 ];
 
@@ -147,6 +178,47 @@ function handleListThreats(args: Record<string, unknown>): ToolResult {
   };
 }
 
+async function handleReportThreat(args: Record<string, unknown>): Promise<ToolResult> {
+  const input: SubmitInput = {
+    url: String(args.url ?? ""),
+    source_url: String(args.source_url ?? ""),
+    description: String(args.description ?? ""),
+    severity: args.severity as SubmitInput["severity"],
+  };
+  try {
+    const result = await submitThreatReport(input);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              message:
+                "PR を起票しました。pr-validate が自動検証を実行します。レビュアー merge で本登録されます。",
+              ...result,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  } catch (err) {
+    if (err instanceof ReportValidationError) {
+      return {
+        content: [{ type: "text", text: `Validation error (${err.field}): ${err.message}` }],
+        isError: true,
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `Internal error: ${message}` }],
+      isError: true,
+    };
+  }
+}
+
 async function executeTool(
   name: string,
   args: Record<string, unknown>,
@@ -156,6 +228,8 @@ async function executeTool(
       return handleCheckDomain(args);
     case "list_threats":
       return handleListThreats(args);
+    case "report_threat":
+      return handleReportThreat(args);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],


### PR DESCRIPTION
廃止していた `report-threat` を「PR 起票ヘルパー」方式で復活。検証は新規実装せず、`pr-validate.yml` + `validate-pr.ts` の既存機構をそのまま流用する。

## 設計

```
[ AI/User ]
   │
   ↓ POST /api/report-threat   または   MCP report_threat
   │  入力: { url, source_url, description, severity? }
   │
[ src/lib/report.ts: submitThreatReport() ]
   │  GitHub REST API:
   │   1. main HEAD SHA 取得
   │   2. ブランチ report/<host>-<unix_ts> 作成
   │   3. data/threats/domains/<host>.json 作成
   │   4. PR 起票
   │
   ↓ 返却: { pr_url, pr_number, branch, host }
   │
[ PR ] ── pr-validate.yml が発火 (auto/* 除外条件を自然に通過)
   │
   ↓ validate-pr.ts: scan() + research() → コメント投稿
   │  ブロッカーありなら CI 失敗で merge ブロック
   │
   ↓ レビュアーが merge / close
```

## 入力スキーマ (API/MCP 共通)

| フィールド | 必須 | 用途 |
|---|---|---|
| `url` | ✓ | scan の対象 + Threat.url |
| `source_url` | ✓ | research の対象 + Threat.source_url (出典必須ポリシー) |
| `description` | ✓ (≥20 文字) | レビュアー判断材料 + Threat.description |
| `severity` | optional | 送信者見立て (scan が再判定で上書き) |

## 変更ファイル

- 新規 `src/lib/report.ts` — GitHub REST API ベースの PR 起票
- 新規 `src/api/report-threat.ts` — 薄い HTTP ラッパ
- 修正 `src/mcp/index.ts` — `report_threat` ツール追加
- 更新 `README.md` / `public/docs.html` / `public/llms.txt` — 3 経路 (REST / MCP / 直接 PR) 案内に統一

## 検証

- `npx tsc --noEmit` PASS
- `npm run build` で 5 Functions ビルド成功 (check-domain / list-threats / mcp / stats / report-threat)
- 検証経路: report/* ブランチは pr-validate.yml の `if: !startsWith(github.head_ref, 'auto/')` を満たすため自動発火
- `source_url` 必須化は `src/lib/report.ts:validateInput()` と `pr-validate.ts` の二段で担保

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5fjck3UHJqNYB6m1pAdBu)_