### PR TITLE
fix: LP の脅威報告リンクを 3 経路案内ページに向ける

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -142,7 +142,7 @@
         <p class="text-gray-400 mb-8">Integrate HTSBP into your workflow via REST API or MCP server.</p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
           <a href="/docs.html" class="px-6 py-3 rounded-lg bg-accent text-bg font-semibold hover:bg-cyan-400 transition">Read the Docs</a>
-          <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener" class="px-6 py-3 rounded-lg border border-gray-600 text-gray-300 font-semibold hover:border-gray-400 hover:text-gray-100 transition">Contribute a Threat (PR)</a>
+          <a href="/docs.html#report" class="px-6 py-3 rounded-lg border border-gray-600 text-gray-300 font-semibold hover:border-gray-400 hover:text-gray-100 transition">Report a Threat</a>
         </div>
       </div>
     </section>
@@ -261,8 +261,8 @@
         resultsDiv.innerHTML = `
           <div class="animate-fade-in rounded-xl border border-green-500/50 bg-green-950/30 p-6 glow-safe">
             <div class="text-xl font-bold text-green-400 mb-2">Good news — no threats found!</div>
-            <p class="text-gray-400 text-sm mb-3">This domain is not in our threat database. If you believe it should be, please contribute it via Pull Request.</p>
-            <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener" class="text-accent text-sm hover:underline">Contribute via PR &rarr;</a>
+            <p class="text-gray-400 text-sm mb-3">This domain is not in our threat database. If you believe it should be, you can report it via API, MCP, or Pull Request.</p>
+            <a href="/docs.html#report" class="text-accent text-sm hover:underline">Report this domain &rarr;</a>
           </div>`;
       }
     }


### PR DESCRIPTION
LP の脅威報告ボタン/リンクが「PR 単独」表記のままだったので、`/docs.html#report` (REST API / MCP / 直接 PR の 3 経路案内が揃ったセクション) に誘導するよう修正。

| 場所 | Before | After |
|---|---|---|
| ヒーロー下ボタン | `Contribute a Threat (PR)` → GitHub raw | `Report a Threat` → `/docs.html#report` |
| 「Good news」検索結果ブロック | `Contribute via PR` → GitHub raw | `Report this domain` → `/docs.html#report` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5fjck3UHJqNYB6m1pAdBu)_