### PR TITLE
fix: docs の Report a Threat を 3 経路均等表示に書き直し

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -343,28 +343,84 @@ console.log(result);</code></pre>
 
       <!-- Contribute -->
       <section id="report">
-        <h2 class="text-2xl font-bold mb-4">Contribute a Threat</h2>
-        <p class="text-gray-400 mb-4">Found a website with hidden prompt injection targeting AI agents? You have three equivalent paths — all of them go through the same validation pipeline (scan + research) and require a reviewer to merge before the threat is registered.</p>
+        <h2 class="text-2xl font-bold mb-4">Report a Threat</h2>
+        <p class="text-gray-400 mb-6">Found a website with hidden prompt injection targeting AI agents? Choose any of the three equivalent paths — all go through the same validation pipeline (scan + research) and require a reviewer to merge before the threat is registered.</p>
 
-        <h3 class="text-sm font-semibold text-gray-300 mb-2">Path A: REST API (programmatic)</h3>
-        <p class="text-gray-400 text-sm mb-3">Send <code class="text-accent">POST /api/report-threat</code>. The API opens a PR on your behalf and returns the PR URL. See the <a href="#report-threat-api" class="text-accent hover:underline">report-threat</a> endpoint docs above.</p>
+        <div class="grid md:grid-cols-3 gap-4 mb-6">
+          <a href="#path-rest" class="block bg-gray-900 rounded-xl p-4 border border-gray-800 hover:border-accent transition">
+            <div class="text-xs uppercase tracking-wider text-gray-500 mb-1">Path A</div>
+            <div class="font-semibold text-gray-100 mb-1">REST API</div>
+            <div class="text-xs text-gray-500"><code class="text-accent">POST /api/report-threat</code></div>
+          </a>
+          <a href="#path-mcp" class="block bg-gray-900 rounded-xl p-4 border border-gray-800 hover:border-accent transition">
+            <div class="text-xs uppercase tracking-wider text-gray-500 mb-1">Path B</div>
+            <div class="font-semibold text-gray-100 mb-1">MCP Tool</div>
+            <div class="text-xs text-gray-500"><code class="text-accent">report_threat</code></div>
+          </a>
+          <a href="#path-pr" class="block bg-gray-900 rounded-xl p-4 border border-gray-800 hover:border-accent transition">
+            <div class="text-xs uppercase tracking-wider text-gray-500 mb-1">Path C</div>
+            <div class="font-semibold text-gray-100 mb-1">Direct Pull Request</div>
+            <div class="text-xs text-gray-500"><code class="text-accent">data/threats/domains/</code></div>
+          </a>
+        </div>
 
-        <h3 class="text-sm font-semibold text-gray-300 mt-5 mb-2">Path B: MCP (AI agents)</h3>
-        <p class="text-gray-400 text-sm mb-3">Call the <code class="text-accent">report_threat</code> MCP tool. Same underlying flow as the REST API — a PR is opened and the URL returned.</p>
+        <h3 id="path-rest" class="text-base font-semibold text-gray-200 mb-2 mt-8">Path A: REST API</h3>
+        <p class="text-gray-400 text-sm mb-3">Send <code class="text-accent">POST /api/report-threat</code> with a JSON body. The API opens a PR on your behalf and returns the PR URL. Full schema in the <a href="#report-threat-api" class="text-accent hover:underline">report-threat endpoint docs</a>.</p>
+        <div class="relative">
+          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
+          <pre><code class="language-bash">curl -X POST "https://hasthissitebeenpoisoned.ai/api/report-threat" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/suspicious",
+    "source_url": "https://researcher.example.com/2026/idpi-report",
+    "description": "Hidden &lt;div style=font-size:0&gt; in the footer with prompt-injection text targeting AI agents",
+    "severity": "high"
+  }'</code></pre>
+        </div>
 
-        <h3 class="text-sm font-semibold text-gray-300 mt-5 mb-2">Path C: Pull Request (manual)</h3>
-        <p class="text-gray-400 text-sm mb-3">Add <code class="text-accent">data/threats/domains/&lt;host&gt;.json</code> directly via a PR on GitHub.</p>
-        <a href="https://github.com/tanbablack/htsbp/blob/main/data/threats/domains" target="_blank" rel="noopener"
-           class="inline-block px-6 py-3 rounded-lg bg-accent text-bg font-semibold hover:bg-cyan-400 transition">
-          Open a Pull Request on GitHub
-        </a>
+        <h3 id="path-mcp" class="text-base font-semibold text-gray-200 mb-2 mt-8">Path B: MCP Tool</h3>
+        <p class="text-gray-400 text-sm mb-3">Call the <code class="text-accent">report_threat</code> tool from any MCP client (Claude Desktop, Cursor, Windsurf, etc.). Same underlying flow as the REST API.</p>
+        <div class="relative">
+          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
+          <pre><code class="language-typescript">await client.callTool("report_threat", {
+  url: "https://example.com/suspicious",
+  source_url: "https://researcher.example.com/2026/idpi-report",
+  description: "Hidden div in the footer with prompt-injection text targeting AI agents",
+  severity: "high"
+});
+// → { pr_url, pr_number, branch, host }</code></pre>
+        </div>
+
+        <h3 id="path-pr" class="text-base font-semibold text-gray-200 mb-2 mt-8">Path C: Direct Pull Request</h3>
+        <p class="text-gray-400 text-sm mb-3">Edit <code class="text-accent">data/threats/domains/&lt;host&gt;.json</code> directly on GitHub.</p>
+        <div class="relative">
+          <button class="copy-btn absolute top-3 right-3 px-2 py-1 rounded text-xs text-gray-400 bg-gray-800" onclick="copyCode(this)">Copy</button>
+          <pre><code class="language-json">{
+  "domain": "example.com",
+  "threats": [
+    {
+      "url": "https://example.com/suspicious",
+      "severity": "high",
+      "intent": "other",
+      "techniques": [],
+      "description": "Hidden div in the footer with prompt-injection text targeting AI agents",
+      "source": "community",
+      "source_url": "https://researcher.example.com/2026/idpi-report",
+      "first_seen": "2026-04-25T00:00:00Z",
+      "last_seen": "2026-04-25T00:00:00Z",
+      "is_active": true
+    }
+  ],
+  "updated_at": "2026-04-25T00:00:00Z"
+}</code></pre>
+        </div>
 
         <div class="mt-6 bg-gray-900 rounded-xl p-4 border border-gray-800 text-sm text-gray-400">
-          <p class="mb-2">All paths require:</p>
+          <p class="mb-2">All three paths require the same fields:</p>
           <ul class="list-disc list-inside space-y-1">
             <li>The full URL where the IDPI payload was observed</li>
             <li><code class="text-accent">source_url</code> — citation to the original report or evidence (required)</li>
-            <li>A description of the hidden instructions or behavior</li>
+            <li>A description of the hidden instructions or behavior (≥ 20 chars for API/MCP)</li>
             <li>(Optional) Your estimated <code class="text-accent">severity</code> (critical / high / medium / low) — the scan pipeline re-derives the final value</li>
           </ul>
           <p class="mt-3 text-gray-500">The PR validation workflow runs our shared <code class="text-accent">scan</code> + <code class="text-accent">research</code> libraries and posts the verdict as a PR comment. Entries without a credible <code class="text-accent">source_url</code> or that are unreachable + unverifiable will fail CI and cannot be merged.</p>


### PR DESCRIPTION
「Open a Pull Request on GitHub」ボタンが単独で目立ち、3 経路均等の建付けが伝わっていなかったので、Report a Threat セクションを 3 経路均等のレイアウトに書き換えた。

## 修正内容

| 要素 | Before | After |
|---|---|---|
| 見出し | Contribute a Threat | Report a Threat |
| 概要下 | (なし) | Path A/B/C のチップを 3 列グリッドで配置、各セクションへのアンカーリンク |
| Path A | 文章のみ (endpoint docs リンク) | curl 例 (実行可能なリクエスト本文付き) |
| Path B | 文章のみ | callTool() の TypeScript 例 |
| Path C | 大きな PR ボタン (これだけ目立っていた) | JSON ファイル例 (Path A/B と同じ重み) |

これで 3 経路が視覚的に均等となり「REST/MCP/PR のどれを使ってもよい」が伝わる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5fjck3UHJqNYB6m1pAdBu)_