### PR TITLE
fix(ci): collect.yml に PR ラベル事前作成ステップを追加

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -24,6 +24,15 @@ jobs:
         run: |
           git config user.name "htsbp-bot"
           git config user.email "bot@hasthissitebeenpoisoned.ai"
+      - name: 0. PR ラベル整備 (idempotent)
+        # collect.ts / recheck.ts が `gh pr create --label auto-collect/auto-recheck/needs-review`
+        # を呼ぶため、未作成だと PR 作成全体が失敗する。`--force` で「無ければ作る/有れば更新」する。
+        run: |
+          gh label create auto-collect --description "新規ドメイン自動収集 PR (要レビュー)" --color 0E8A16 --force
+          gh label create auto-recheck --description "既存ドメイン再検証で変化を検出した PR (要レビュー)" --color 1D76DB --force
+          gh label create needs-review --description "Low-confidence finding, needs manual review" --color FBCA04 --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 1. 新規ドメイン発見+判定+反映
         run: npm run collect
         env:


### PR DESCRIPTION
`auto-collect` / `auto-recheck` ラベルが repo 上に存在しなかったため collect.ts / recheck.ts 内の `gh pr create --label auto-collect ...` が一律失敗し、ブランチは push されるが PR が起票されない状態になっていた
(remote 上に PR なしの auto/recheck/* ブランチが多数滞留)。

`gh label create --force` でべき等に「無ければ作る/有れば更新」する
ステップを collect / recheck 実行前に挿入して恒久対策とする。