### PR TITLE
fix(ci): auto/* への git push を --force にして non-fast-forward を回避

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -507,7 +507,7 @@ async function reflectOne(c: Candidate, j: ComprehensiveJudgment): Promise<void>
     execGit(
       `git commit -m ${JSON.stringify(`data: 新規IDPI候補 ${c.host} を追加 (要レビュー)`)}`,
     );
-    execGit(`git push -u origin ${branch}`);
+    execGit(`git push -u --force origin ${branch}`);
     await openPrViaCli(branch, `data: 新規IDPI候補 ${c.host} を追加 (要レビュー)`, bodyPath);
     execGit("git checkout main");
   } catch (err) {

--- a/src/recheck.ts
+++ b/src/recheck.ts
@@ -213,7 +213,7 @@ async function openPrForRecheck(host: string, diff: Diff): Promise<void> {
     execGit(`git checkout -B ${branch}`);
     execGit(`git add ${JSON.stringify(filePath)} ${JSON.stringify(indexRel)}`);
     execGit(`git commit -m ${JSON.stringify(`data: ${host} 再検証で変化を検出 (要レビュー)`)}`);
-    execGit(`git push -u origin ${branch}`);
+    execGit(`git push -u --force origin ${branch}`);
     execSync(
       `gh pr create --title ${JSON.stringify(`data: ${host} 再検証で変化を検出 (要レビュー)`)} --body-file ${JSON.stringify(bodyPath)} --base main --head ${branch} --label auto-recheck --label needs-review`,
       { cwd: PROJECT_ROOT, stdio: "inherit" },


### PR DESCRIPTION
## 概要

前 PR (#20) でラベル不在を解消、その後リポジトリ設定 "Allow GitHub Actions to create and approve pull requests" を有効化したことで `gh pr create` 段は通るようになった。しかし新たに以下のエラーで `git push` 段が失敗するようになった:

```
! [rejected] auto/recheck/<host>-20260503 -> auto/recheck/<host>-20260503 (non-fast-forward)
```

## 原因

同日内に collect / recheck を複数回実行すると:

- ブランチ名は `auto/recheck/<host>-<YYYYMMDD>` で日付ベース → 同じ名前
- 一方コミット内容には `updated_at` / `last_seen` に `new Date().toISOString()` が入る → 実行ごとに timestamp 変動
- 結果、parent (main HEAD) は同じだが SHA の異なる divergent sibling commit が毎回生成され、2 回目以降の push が fast-forward 不可で reject される

`gh pr create` まで到達しないので PR が立たないループ。

## 修正

`src/collect.ts:510` と `src/recheck.ts:216` の `git push -u origin <branch>` を `git push -u --force origin <branch>` に変更。auto/* ブランチは workflow が単独所有しており、レビュー前は誰も commit を積まない前提なので force push で問題ない。

`--force-with-lease` は事前 `git fetch <branch>` していない (= ローカルが remote の現在 SHA を知らない) ため使えない。fetch を足してもコストの割に得るものが少ないので素朴な `--force` を採用。

## 期待される挙動

1. 同日 2 回目以降の dispatch でも push 成功
2. 同名ブランチに最新の timestamp / 内容を上書き push
3. 既存の PR (もしあれば) は自動で同期される

https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs)_