### PR TITLE
feat(recheck): 既存ドメイン再検証を PR 起票廃止し main に直接反映

### DIFF
--- a/src/recheck.ts
+++ b/src/recheck.ts
@@ -3,7 +3,10 @@
  *
  * data/threats/domains/<host>.json 全件を対象に scanUrl() を実行し、
  * 到達性 / severity / techniques に変化があれば該当レコードを更新して
- * ドメインごとに個別 PR を起票する。
+ * 直接 main にコミット (ドメインごとに 1 commit) して push する。
+ *
+ * 新規ドメイン発見と異なり、再検証は scan() 結果に基づく機械的な
+ * 状態追従なので人間レビューを介在させない方針。
  *
  * レート制御: 1 日あたり最大 100 ドメイン (last_seen が古い順)。
  */
@@ -199,30 +202,25 @@ function execGit(cmd: string): string {
   return execSync(cmd, { cwd: PROJECT_ROOT, encoding: "utf-8" }).trim();
 }
 
-async function openPrForRecheck(host: string, diff: Diff): Promise<void> {
-  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
-  const branch = `auto/recheck/${host}-${date}`;
+function buildSubject(host: string, diff: Diff): string {
+  const parts: string[] = [];
+  if (diff.reachabilityChanged) parts.push(`is_active=${diff.after.isActive}`);
+  if (diff.severityChanged) parts.push(`severity ${diff.before.severity}→${diff.after.severity}`);
+  if (diff.newTechniques.length > 0) parts.push(`+techniques`);
+  return `data(recheck): ${host} ${parts.join(" / ")}`;
+}
+
+function commitDiffToMain(host: string, diff: Diff): void {
   const filePath = path.relative(PROJECT_ROOT, path.join(DOMAINS_DIR, `${host}.json`));
   const indexRel = path.relative(PROJECT_ROOT, INDEX_PATH);
-  const bodyPath = path.join(PROJECT_ROOT, `.pr-body-recheck-${host}.md`);
-  fs.writeFileSync(bodyPath, renderDiffMd(host, diff));
-
+  const msgPath = path.join(PROJECT_ROOT, `.commit-msg-recheck-${host}.txt`);
+  const subject = buildSubject(host, diff);
+  fs.writeFileSync(msgPath, `${subject}\n\n${renderDiffMd(host, diff)}\n`);
   try {
-    execGit("git config user.name htsbp-bot");
-    execGit("git config user.email bot@hasthissitebeenpoisoned.ai");
-    execGit(`git checkout -B ${branch}`);
     execGit(`git add ${JSON.stringify(filePath)} ${JSON.stringify(indexRel)}`);
-    execGit(`git commit -m ${JSON.stringify(`data: ${host} 再検証で変化を検出 (要レビュー)`)}`);
-    execGit(`git push -u --force origin ${branch}`);
-    execSync(
-      `gh pr create --title ${JSON.stringify(`data: ${host} 再検証で変化を検出 (要レビュー)`)} --body-file ${JSON.stringify(bodyPath)} --base main --head ${branch} --label auto-recheck --label needs-review`,
-      { cwd: PROJECT_ROOT, stdio: "inherit" },
-    );
-    execGit("git checkout main");
-  } catch (err) {
-    console.warn(`[recheck] PR 起票失敗 ${host}:`, err instanceof Error ? err.message : err);
+    execGit(`git commit -F ${JSON.stringify(msgPath)}`);
   } finally {
-    fs.rmSync(bodyPath, { force: true });
+    fs.rmSync(msgPath, { force: true });
   }
 }
 
@@ -237,6 +235,10 @@ async function main(): Promise<void> {
   const targets = all.slice(0, MAX_PER_DAY);
   console.log(`[recheck] 対象 ${targets.length}/${all.length} 件`);
 
+  try { execGit("git config user.name htsbp-bot"); } catch { /* ignore */ }
+  try { execGit("git config user.email bot@hasthissitebeenpoisoned.ai"); } catch { /* ignore */ }
+  try { execGit("git checkout main"); } catch { /* already on main */ }
+
   let changed = 0;
   for (const entry of targets) {
     console.log(`[recheck] scanning ${entry.host}...`);
@@ -247,12 +249,32 @@ async function main(): Promise<void> {
         continue;
       }
       rebuildIndex();
-      await openPrForRecheck(entry.host, diff);
+      commitDiffToMain(entry.host, diff);
+      console.log(`[recheck] ${entry.host}: ${buildSubject(entry.host, diff)}`);
       changed++;
     } catch (err) {
       console.warn(`[recheck] ${entry.host} 失敗:`, err instanceof Error ? err.message : err);
     }
   }
+
+  if (changed > 0) {
+    try {
+      execGit("git push origin main");
+      console.log(`[recheck] main へ ${changed} commit を push`);
+    } catch (err) {
+      // 同時実行で main が進んでいた場合の保険: rebase してリトライ
+      console.warn("[recheck] push 失敗、rebase 後リトライ:", err instanceof Error ? err.message : err);
+      try {
+        execGit("git pull --rebase origin main");
+        execGit("git push origin main");
+        console.log(`[recheck] rebase 後 push 成功`);
+      } catch (err2) {
+        console.error("[recheck] rebase 後も push 失敗:", err2 instanceof Error ? err2.message : err2);
+        process.exit(1);
+      }
+    }
+  }
+
   console.log(`[recheck] 完了: 変化検出 ${changed} 件`);
 }
 


### PR DESCRIPTION
## 概要

既存ドメインの再検証 (`recheck.ts`) を PR 起票方式から **main 直接 commit & push** 方式に変更する。新規ドメインの発見 (`collect.ts`) は今まで通り PR 経由で人間レビューを介する。

## 動機

再検証は `scan()` の機械的な再評価 (到達性 / severity / 新規 techniques) であり、

- 既に登録済みドメインへの差分追記なので閾値判定は collect 段で済んでいる
- 毎日 100 件まで PR が量産される (今回 1 回の dispatch で 24 件出た)
- レビュー粒度が細かすぎて人間がさばき切れない

ため、人間レビューを介在させる意義が薄い。新規発見 (collect) のみ PR で温度感を保つ。

## 変更点 (`src/recheck.ts`)

- `openPrForRecheck()` 廃止
- `commitDiffToMain()` 新設: ドメインごとに 1 commit を main に積む
  - 件名: `data(recheck): <host> <要約>` (例: `severity high→critical`, `is_active=false`)
  - 本文: `renderDiffMd()` の判定根拠 (これまで PR body に入れていたものをそのまま commit message body に)
- `main()` の最後に `git push origin main` を 1 回。non-fast-forward だった場合は `git pull --rebase` してリトライ

## 期待される挙動

| | 変更前 | 変更後 |
|---|---|---|
| 1 回の recheck で立つ PR 数 | 最大 100 | **0** |
| 再検証差分の反映タイミング | レビュー&マージ後 | 即時 |
| 監査証跡 | PR 履歴 | git log (`data(recheck):` で grep 可能) |
| 新規発見 PR (collect) | 維持 | 維持 |

## 既存の auto-recheck PR (#22-#45) について

→ 別途方針を決めて頂く必要あり (このセクションは PR の本文では削除)

https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs)_