### PR TITLE
chore(ci): collect.yml から不要な auto-recheck ラベル作成行を削除

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -25,11 +25,11 @@ jobs:
           git config user.name "htsbp-bot"
           git config user.email "bot@hasthissitebeenpoisoned.ai"
       - name: 0. PR ラベル整備 (idempotent)
-        # collect.ts / recheck.ts が `gh pr create --label auto-collect/auto-recheck/needs-review`
-        # を呼ぶため、未作成だと PR 作成全体が失敗する。`--force` で「無ければ作る/有れば更新」する。
+        # collect.ts が `gh pr create --label auto-collect/needs-review` を呼ぶため、
+        # 未作成だと PR 作成が失敗する。`--force` で「無ければ作る/有れば更新」する。
+        # (recheck.ts は main 直接 commit 方式に変更したのでラベル不要)
         run: |
           gh label create auto-collect --description "新規ドメイン自動収集 PR (要レビュー)" --color 0E8A16 --force
-          gh label create auto-recheck --description "既存ドメイン再検証で変化を検出した PR (要レビュー)" --color 1D76DB --force
           gh label create needs-review --description "Low-confidence finding, needs manual review" --color FBCA04 --force
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

PR #46 で `recheck.ts` を「main に直接 commit&push」方式に変更したことで `auto-recheck` ラベルを使う箇所が無くなったため、`.github/workflows/collect.yml` の事前作成ステップから当該行を削除する。

`auto-collect` ラベルは collect.ts (新規ドメイン PR) で引き続き使うため残す。

## 補足: 残課題

`auto/recheck/<host>-20260503` ブランチ 24 本が remote に滞留しています。このサンドボックス環境からは git proxy が delete-ref を 403 で拒否するため削除できません。GitHub UI からまとめて削除するか、ローカル shell から下記を実行してください:

```bash
for b in $(git branch -r | grep "auto/recheck/.*-20260503$" | sed 's|.*origin/||'); do
  git push origin --delete "$b"
done
```

削除順序は不問。すべての PR は close 済みなので参照していません。

https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgVHqnNxpLGuZESMmTeLAs)_