### PR TITLE
Improve OTX API error handling and observability

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -114,51 +114,78 @@ interface OtxPulse {
   modified: string;
 }
 
-async function otxFetch<T>(url: string): Promise<T | null> {
+interface OtxFetchResult<T> {
+  data: T | null;
+  lastStatus: number | null;
+  lastError: string | null;
+}
+
+async function otxFetch<T>(url: string): Promise<OtxFetchResult<T>> {
   const headers: Record<string, string> = {
     Accept: "application/json",
     "User-Agent": "htsbp-collect/1.0",
   };
   if (process.env.OTX_API_KEY) headers["X-OTX-API-KEY"] = process.env.OTX_API_KEY;
-  for (let attempt = 0; attempt < 3; attempt++) {
+  const path = (() => {
+    try { const u = new URL(url); return u.pathname + u.search; } catch { return url; }
+  })();
+  const MAX = 5;
+  let lastStatus: number | null = null;
+  let lastError: string | null = null;
+  for (let attempt = 0; attempt < MAX; attempt++) {
     try {
       const ctrl = new AbortController();
-      const timer = setTimeout(() => ctrl.abort(), 15_000);
+      const timer = setTimeout(() => ctrl.abort(), 30_000);
       const res = await fetch(url, { headers, signal: ctrl.signal });
       clearTimeout(timer);
-      if (res.status === 504 || res.status === 503 || res.status === 429) {
-        await new Promise((r) => setTimeout(r, 3000 * 2 ** attempt));
+      lastStatus = res.status;
+      lastError = null;
+      if (res.status === 429 || (res.status >= 500 && res.status < 600)) {
+        console.log(`[otxFetch] ${path} attempt ${attempt + 1}/${MAX}: HTTP ${res.status} (retrying)`);
+        if (attempt < MAX - 1) await new Promise((r) => setTimeout(r, 3000 * 2 ** attempt));
         continue;
       }
-      if (!res.ok) return null;
-      return (await res.json()) as T;
-    } catch {
-      if (attempt === 2) return null;
-      await new Promise((r) => setTimeout(r, 3000 * 2 ** attempt));
+      if (!res.ok) {
+        console.log(`[otxFetch] ${path} attempt ${attempt + 1}/${MAX}: HTTP ${res.status} (giving up)`);
+        return { data: null, lastStatus, lastError: null };
+      }
+      const json = (await res.json()) as T;
+      if (attempt > 0) console.log(`[otxFetch] ${path}: OK on attempt ${attempt + 1}`);
+      return { data: json, lastStatus, lastError: null };
+    } catch (e) {
+      lastError = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+      console.log(`[otxFetch] ${path} attempt ${attempt + 1}/${MAX}: ${lastError} (retrying)`);
+      if (attempt < MAX - 1) await new Promise((r) => setTimeout(r, 3000 * 2 ** attempt));
     }
   }
-  return null;
+  console.log(`[otxFetch] ${path}: FAILED after ${MAX} attempts (lastStatus=${lastStatus}, lastError=${lastError})`);
+  return { data: null, lastStatus, lastError };
 }
 
 async function discoverFromOtxApi(known: Set<string>): Promise<Candidate[]> {
   const out: Candidate[] = [];
   const seen = new Set<string>();
   let termsSucceeded = 0;
+  const termOutcomes: string[] = [];
   for (const term of OTX_TERMS) {
     if (seen.size >= OTX_MAX_TOTAL_DOMAINS) break;
-    const data = await otxFetch<{ results: OtxPulse[] }>(
+    const r = await otxFetch<{ results: OtxPulse[] }>(
       `${OTX_API}/search/pulses?q=${encodeURIComponent(term)}&limit=20`,
     );
-    if (!data) continue;
+    if (!r.data) {
+      termOutcomes.push(`"${term}"=${r.lastError ?? `HTTP ${r.lastStatus ?? "?"}`}`);
+      continue;
+    }
     termsSucceeded++;
-    for (const pulse of data.results ?? []) {
+    termOutcomes.push(`"${term}"=OK`);
+    for (const pulse of r.data.results ?? []) {
       const text = `${pulse.name} ${pulse.description}`.toLowerCase();
       if (!OTX_RELEVANCE.some((kw) => text.includes(kw))) continue;
       const indicators: OtxIndicator[] = pulse.indicators?.length
         ? pulse.indicators.slice(0, OTX_MAX_INDICATORS_PER_PULSE)
         : ((await otxFetch<{ results: OtxIndicator[] }>(
             `${OTX_API}/pulses/${pulse.id}/indicators?limit=${OTX_MAX_INDICATORS_PER_PULSE}`,
-          ))?.results ?? []);
+          )).data?.results ?? []);
       for (const ind of indicators) {
         if (seen.size >= OTX_MAX_TOTAL_DOMAINS) break;
         let host: string | null = null;
@@ -180,7 +207,7 @@ async function discoverFromOtxApi(known: Set<string>): Promise<Candidate[]> {
     }
   }
   if (termsSucceeded === 0) {
-    throw new Error(`OTX: 全 ${OTX_TERMS.length} term の fetch がリトライ後も失敗`);
+    throw new Error(`OTX: 全 ${OTX_TERMS.length} term 失敗 [${termOutcomes.join(", ")}]`);
   }
   return out;
 }


### PR DESCRIPTION
## Summary
Enhanced the OTX API fetch function with better error handling, retry logic, and comprehensive logging to improve debugging and reliability.

## Key Changes
- **Return type refactoring**: Changed `otxFetch()` to return `OtxFetchResult<T>` containing data, HTTP status, and error details instead of just `T | null`, enabling better error context propagation
- **Improved retry logic**: 
  - Increased max retry attempts from 3 to 5
  - Extended timeout from 15s to 30s per request
  - Expanded retryable status codes to include all 5xx errors (not just 503/504), plus 429 (rate limit)
  - Only retry on the last attempt if it's not the final one
- **Enhanced logging**: Added detailed console logs for each fetch attempt showing:
  - Request path (extracted from URL)
  - Attempt number and max attempts
  - HTTP status codes or error details
  - Success on retry attempts
  - Final failure summary with last status and error
- **Better error tracking**: Capture and format exception details (name and message) for improved diagnostics
- **Improved error messages**: Updated OTX discovery failure message to include per-term outcomes showing which terms failed and why

## Implementation Details
- URL path extraction handles both valid URLs and fallback to raw URL string
- Error messages preserve both HTTP status and exception details for comprehensive debugging
- Logging uses consistent format: `[otxFetch] {path} attempt {n}/{MAX}: {status/error} ({action})`
- Term outcomes tracked and reported in final error to help identify problematic search terms

https://claude.ai/code/session_01E7dXYbHdnW9HVgsp6AgMKR