### PR TITLE
Upgrade to Claude Opus 5 with extended token limits and fallback routing

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -28,7 +28,7 @@ const DOMAINS_DIR = path.join(DATA_DIR, "threats/domains");
 const SOURCES_PATH = path.join(DATA_DIR, "sources.json");
 
 const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
-const MODEL = "claude-opus-4-8";
+const MODEL = "claude-opus-5";
 
 const OTX_API = "https://otx.alienvault.com/api/v1";
 const OTX_TERMS = ["prompt injection", "IDPI", "indirect prompt injection"];
@@ -259,11 +259,16 @@ JSON のみ。前置き・後書き不要。全フィールド日本語/英語�
       "Content-Type": "application/json",
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "server-side-fallback-2026-07-01",
     },
     body: JSON.stringify({
       model: MODEL,
-      max_tokens: 4000,
-      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 6 }],
+      // Opus 5 は thinking がデフォルト ON。max_tokens は thinking + 本文の合計上限
+      max_tokens: 8000,
+      // IDPI 情報源の巡回で cyber 分類器の誤検知 refusal があり得るため
+      // fallbacks で代替モデルに自動再ルーティングする
+      fallbacks: "default",
+      tools: [{ type: "web_search_20260209", name: "web_search", max_uses: 6 }],
       messages: [{ role: "user", content: prompt }],
     }),
   });

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -7,7 +7,7 @@
 import type { ResearchResult } from "../types.js";
 
 const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
-const MODEL = "claude-opus-4-8";
+const MODEL = "claude-opus-5";
 
 export async function researchDomain(
   host: string,
@@ -58,12 +58,17 @@ JSON のみ。前置き・後書き不要。全フィールド日本語で記述
       "Content-Type": "application/json",
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "server-side-fallback-2026-07-01",
     },
     body: JSON.stringify({
       model: MODEL,
-      max_tokens: 1500,
+      // Opus 5 は thinking がデフォルト ON。max_tokens は thinking + 本文の合計上限
+      max_tokens: 8000,
+      // IDPI 関連ドメインの調査で cyber 分類器の誤検知 refusal があり得るため
+      // fallbacks で代替モデルに自動再ルーティングする
+      fallbacks: "default",
       tools: [
-        { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+        { type: "web_search_20260209", name: "web_search", max_uses: 5 },
       ],
       messages: [{ role: "user", content: prompt }],
     }),

--- a/src/lib/scan.ts
+++ b/src/lib/scan.ts
@@ -12,7 +12,7 @@ import type {
 } from "../types.js";
 
 const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
-const MODEL = "claude-opus-4-8";
+const MODEL = "claude-opus-5";
 const HTTP_TIMEOUT_MS = 15_000;
 const HTML_EXCERPT_BYTES = 30_000;
 
@@ -171,10 +171,15 @@ JSON のみ。前置き・後書き不要。全フィールド日本語で記述
       "Content-Type": "application/json",
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "server-side-fallback-2026-07-01",
     },
     body: JSON.stringify({
       model: MODEL,
-      max_tokens: 1024,
+      // Opus 5 は thinking がデフォルト ON。max_tokens は thinking + 本文の合計上限
+      max_tokens: 8000,
+      // 攻撃ページの HTML を解析させるため cyber 分類器の誤検知 refusal があり得る。
+      // fallbacks でカテゴリに応じた代替モデル (Opus 4.8 等) に自動再ルーティングする
+      fallbacks: "default",
       messages: [{ role: "user", content: prompt }],
     }),
   });


### PR DESCRIPTION
## Summary
Upgrade the Anthropic Claude model from `claude-opus-4-8` to `claude-opus-5` across all API calls, with corresponding adjustments to token limits and addition of automatic fallback routing to handle potential refusals from the cyber classifier.

## Key Changes
- **Model upgrade**: Updated all three modules (`collect.ts`, `research.ts`, `scan.ts`) to use `claude-opus-5` instead of `claude-opus-4-8`
- **Token limit increases**: Increased `max_tokens` from 1024-4000 to 8000 across all modules to account for Opus 5's default-enabled thinking capability (where `max_tokens` now covers both thinking and output tokens combined)
- **Fallback routing**: Added `"anthropic-beta": "server-side-fallback-2026-07-01"` header and `fallbacks: "default"` parameter to enable automatic model fallback when the cyber classifier incorrectly refuses requests related to IDPI (indirect prompt injection) and attack analysis
- **Web search tool update**: Updated web search tool version from `web_search_20250305` to `web_search_20260209`

## Implementation Details
The fallback mechanism is particularly important for this use case since the application analyzes potentially malicious domains and attack pages, which may trigger false positives in the cyber classifier. The automatic fallback routing allows requests to be rerouted to alternative models (such as Opus 4.8) when necessary, ensuring reliability without manual intervention.

All three modules follow the same upgrade pattern with consistent token limits and fallback configuration, ensuring uniform behavior across the threat intelligence collection, domain research, and page scanning workflows.

https://claude.ai/code/session_01Ng7ffmgcwvUFudAqmNYCjA